### PR TITLE
Make compatible with Laravel 5.3

### DIFF
--- a/src/FailedJobNotifier.php
+++ b/src/FailedJobNotifier.php
@@ -14,7 +14,7 @@ class FailedJobNotifier
 
         app(QueueManager::class)->failing(function (JobFailed $event) use ($sender) {
 
-            $sender->send(json_encode($event->data));
+            $sender->send(json_encode($event->job->payload()));
         });
     }
 


### PR DESCRIPTION
Various queue job events such as JobProcessing, JobProcessed and JobFailed no longer contain the $data property. Should use `$event->job->payload()` to get the equivalent data.