### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ You can install the package via composer:
 ``` bash
 composer require spatie/laravel-failed-job-monitor
 ```
+If you intend to use Slack notifications you should also install the guzzle client:
+
+``` bash
+composer require guzzlehttp/guzzle
+```
 
 Next up, the service provider must be registered:
 


### PR DESCRIPTION
A very minor change to make it explicit to install Guzzle if you want to use Slack notifications 