### PR TITLE
Implement killswitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,39 @@ php artisan vendor:publish --provider="Spatie\FailedJobMonitor\FailedJobMonitorS
 This is the contents of the default configuration file.  Here you can specify the notifiable to which the notifications should be sent. The default notifiable will use the variables specified in this config file.
 
 ```php
+<?php
+
 return [
 
-    /**
+    /*
      * The notification that will be sent when a job fails.
      */
     'notification' => \Spatie\FailedJobMonitor\Notification::class,
 
-    /**
+    /*
      * The notifiable to which the notification will be sent. The default
      * notifiable will use the mail and slack configuration specified
      * in this config file.
      */
     'notifiable' => \Spatie\FailedJobMonitor\Notifiable::class,
 
-    /**
+    /*
+     * By default notifications are sent for all failures. You can pass a callable to filter
+     * out certain notifications. The given callable will receive the notification. If the callable
+     * return false, the notification will not be sent.
+     */
+    'notificationFilter' => null,
+
+    /*
      * The channels to which the notification will be sent.
      */
     'channels' => ['mail', 'slack'],
+
+    /*
+     * If you need to turn off the failed job notifications,
+     * this provides you a quick killswitch to turn them off
+     */
+    'killswitch' => env('FAILED_JOB_MONITOR_KILLSWITCH', false),
 
     'mail' => [
         'to' => 'email@example.com',
@@ -93,6 +108,9 @@ return [
     'notifiable' => \App\CustomNotifiableForFailedJobMonitor::class,
     ...
 ```
+### Kill Switch
+
+If you are working locally and offline or have another reason to turn off the failed job notifications, you can set the `FAILED_JOB_MONITOR_KILLSWITCH=true` in your `.env` file to turn off the notifications.
 
 ## Usage
 

--- a/config/failed-job-monitor.php
+++ b/config/failed-job-monitor.php
@@ -26,6 +26,8 @@ return [
      */
     'channels' => ['mail', 'slack'],
 
+    'killswitch' => env('FAILED_JOB_MONITOR_KILLSWITCH', false),
+
     'mail' => [
         'to' => 'email@example.com',
     ],

--- a/config/failed-job-monitor.php
+++ b/config/failed-job-monitor.php
@@ -26,6 +26,10 @@ return [
      */
     'channels' => ['mail', 'slack'],
 
+    /*
+     * If you need to turn off the failed job notifications,
+     * this provides you a quick killswitch to turn them off
+     */
     'killswitch' => env('FAILED_JOB_MONITOR_KILLSWITCH', false),
 
     'mail' => [

--- a/src/FailedJobNotifier.php
+++ b/src/FailedJobNotifier.php
@@ -40,6 +40,10 @@ class FailedJobNotifier
 
     public function shouldSendNotification($notification)
     {
+        if (config('failed-job-monitor.killswitch', false)) {
+            return false;
+        }
+
         $callable = config('failed-job-monitor.notificationFilter');
 
         if (! is_callable($callable)) {

--- a/tests/FailedJobMonitorTest.php
+++ b/tests/FailedJobMonitorTest.php
@@ -63,6 +63,26 @@ class FailedJobMonitorTest extends TestCase
         NotificationFacade::assertNotSentTo(new Notifiable(), AnotherNotification::class);
     }
 
+    /** @test */
+    public function it_does_not_send_a_notification_when_killswith_is_on()
+    {
+        $this->app['config']->set('failed-job-monitor.killswitch', true);
+
+        $this->fireFailedEvent();
+
+        NotificationFacade::assertNothingSent();
+    }
+
+    /** @test */
+    public function it_does_send_a_notification_when_killswith_is_off()
+    {
+        $this->app['config']->set('failed-job-monitor.killswitch', false);
+
+        $this->fireFailedEvent();
+
+        NotificationFacade::assertSentTo(new Notifiable(), Notification::class);
+    }
+
     protected function fireFailedEvent()
     {
         return event(new JobFailed('test', new Job(), new \Exception()));


### PR DESCRIPTION
This implements a killswitch to prevent notifications from being sent when the killswitch is set to `true`

Fixes #38 