### PR TITLE
Allow null return for routeNotificationForSlack

### DIFF
--- a/src/Notifiable.php
+++ b/src/Notifiable.php
@@ -13,7 +13,7 @@ class Notifiable
         return config('failed-job-monitor.mail.to');
     }
 
-    public function routeNotificationForSlack(): string
+    public function routeNotificationForSlack(): ?string
     {
         return config('failed-job-monitor.slack.webhook_url');
     }


### PR DESCRIPTION
This allows disabling notifications by not providing a webhook url in .env (useful for local environment)