### PR TITLE
allows extension of illuminate notification class

### DIFF
--- a/src/FailedJobNotifier.php
+++ b/src/FailedJobNotifier.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\FailedJobMonitor;
 
+use Illuminate\Notifications\Notification as IlluminateNotification;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\QueueManager;
 use Spatie\FailedJobMonitor\Exceptions\InvalidConfiguration;
@@ -31,7 +32,7 @@ class FailedJobNotifier
             return true;
         }
 
-        if (is_subclass_of($notification, Notification::class)) {
+        if (is_subclass_of($notification, IlluminateNotification::class)) {
             return true;
         }
 


### PR DESCRIPTION
When developing using this package, I wanted to add a new notification type. So I created a new class an extened the `\Illuminate\Notifications\Notification` class however I received an error stating the new class I made had to extend the `Illuminate\Notifications\Notification` class, which my class was doing.

A workaround is extending the `Spatie\FailedJobMonitor\Notification` - however, the error message does not suggest this to be the correct source of action.

This pull request resolves the issue by importing the  `Illuminate\Notifications\Notification` and uses it in the `isValidNotificationClass` method.