### PR TITLE
WIP: Add support for laravel 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,15 +10,20 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [7.2, 7.3, 7.4]
-                laravel: [5.8, 6.*, 7.*]
+                laravel: [5.8, 6.*, 7.*,8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
+                    -   laravel: 8.*
+                        testbench: 6.*
                     -   laravel: 7.*
                         testbench: 5.*
                     -   laravel: 6.*
                         testbench: 4.*
                     -   laravel: 5.8
                         testbench: 3.8
+                exclude:
+                    -   laravel: 8.*
+                        php: 7.2
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to laravel-failed-job-monitor will be documented in this file
 
+## Unreleased
+
+- add support for laravel 8
+
 ## 3.3.1 - 2020-04-20
 
 - allow extending Illuminate notification class (#56)

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
       "Spatie\\FailedJobMonitor\\Test\\": "tests"
     }
   },
+  "minimum-stability": "dev",
   "scripts": {
     "test": "vendor/bin/phpunit"
   },

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
   ],
   "require": {
     "php" : "^7.2",
-    "laravel/framework": "~5.8.0|^6.0|^7.0"
+    "laravel/framework": "~5.8.0|^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
-    "orchestra/testbench":"~3.8.0|^4.0|^5.0"
+    "orchestra/testbench":"~3.8.0|^4.0|^5.0|^6.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR adds support for the upcoming release of laravel 8.
Tests are all passing. I excluded php version 7.2 for laravel 8 since laravel itself requires php 7.3

To get the tests to work I had to set the minimum stability to dev, since laravel 8 is not released yet. This change should probably be reverted before releasing.