### PR TITLE
Add PHP 8-only Support (v4)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,21 +9,14 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [7.3, 7.4, 8.0]
-                laravel: [5.8.*, 6.*, 7.*, 8.*]
+                php: [8.0]
+                laravel: [7.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
                         testbench: 6.*
                     -   laravel: 7.*
                         testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
-                    -   laravel: 5.8.*
-                        testbench: 3.8
-                exclude:
-                    -   laravel: 5.8.*
-                        php: 8.0
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -42,5 +35,6 @@ jobs:
                 run: |
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
             -   name: Execute tests
                 run: vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to laravel-failed-job-monitor will be documented in this file
 
+## 4.0.0 - unreleased
+
+- Require PHP 8+
+- Drop support for PHP 7.x
+- Convert syntax to PHP 8 where possible
+- Drop support for Laravel 5.8, 6.x
 
 ## 3.4.0 - 2020-12-01
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 ## Installation
 
+> For Laravel versions 5.8 and 6.x, use v3.x of this package.
+
 You can install the package via composer:
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The service provider will automatically be registered.
 Next, you must publish the config file:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\FailedJobMonitor\FailedJobMonitorServiceProvider"
+php artisan vendor:publish --tag=laravel-failed-job-monitor-config
 ```
 
 This is the contents of the default configuration file.  Here you can specify the notifiable to which the notifications should be sent. The default notifiable will use the variables specified in this config file.

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,14 @@
         }
     ],
     "require" : {
-        "php" : "^7.3|^8.0",
-        "laravel/framework" : "~5.8.0|^6.0|^7.0|^8.0"
+        "php" : "^8.0",
+        "laravel/framework" : "^7.0|^8.0",
+        "spatie/laravel-package-tools": "^1.6"
     },
     "require-dev" : {
         "phpunit/phpunit" : "^8.5|^9.5",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench" : "~3.8.0|^4.0|^5.0|^6.0"
+        "orchestra/testbench" : "^5.0|^6.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/src/FailedJobMonitorServiceProvider.php
+++ b/src/FailedJobMonitorServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\FailedJobMonitor;
 
-use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class FailedJobMonitorServiceProvider extends PackageServiceProvider
 {

--- a/src/FailedJobMonitorServiceProvider.php
+++ b/src/FailedJobMonitorServiceProvider.php
@@ -2,32 +2,25 @@
 
 namespace Spatie\FailedJobMonitor;
 
-use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LaravelPackageTools\Package;
 
-class FailedJobMonitorServiceProvider extends IlluminateServiceProvider
+class FailedJobMonitorServiceProvider extends PackageServiceProvider
 {
-    /**
-     * Bootstrap the application services.
-     */
-    public function boot()
+    public function configurePackage(Package $package): void
     {
-        $this->publishes([
-            __DIR__.'/../config/failed-job-monitor.php' => config_path('failed-job-monitor.php'),
-        ], 'config');
+        $package
+            ->name('laravel-failed-job-monitor')
+            ->hasConfigFile();
+    }
 
+    public function packageBooted(): void
+    {
         $this->app->make(FailedJobNotifier::class)->register();
     }
 
-    /**
-     * Register the application services.
-     */
-    public function register()
+    public function packageRegistered(): void
     {
-        $this->mergeConfigFrom(
-            __DIR__.'/../config/failed-job-monitor.php',
-            'failed-job-monitor'
-        );
-
         $this->app->singleton(FailedJobNotifier::class);
     }
 }

--- a/src/FailedJobNotifier.php
+++ b/src/FailedJobNotifier.php
@@ -9,7 +9,7 @@ use Spatie\FailedJobMonitor\Exceptions\InvalidConfiguration;
 
 class FailedJobNotifier
 {
-    public function register()
+    public function register(): void
     {
         app(QueueManager::class)->failing(function (JobFailed $event) {
             $notifiable = app(config('failed-job-monitor.notifiable'));
@@ -39,7 +39,7 @@ class FailedJobNotifier
         return false;
     }
 
-    public function shouldSendNotification($notification)
+    public function shouldSendNotification($notification): bool
     {
         $callable = config('failed-job-monitor.notificationFilter');
 

--- a/src/Notifiable.php
+++ b/src/Notifiable.php
@@ -18,10 +18,7 @@ class Notifiable
         return config('failed-job-monitor.slack.webhook_url');
     }
 
-    /**
-     * @return mixed
-     */
-    public function getKey()
+    public function getKey(): int
     {
         return 1;
     }

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -10,8 +10,7 @@ use Illuminate\Queue\Events\JobFailed;
 
 class Notification extends IlluminateNotification
 {
-    /** @var \Illuminate\Queue\Events\JobFailed */
-    protected $event;
+    protected JobFailed $event;
 
     public function via($notifiable): array
     {


### PR DESCRIPTION
This PR adds a new major version, v4.0.0.

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- All syntax converted to PHP 8 where possible.
- Removes unnecessary PHP docblocks per Spatie's guidelines.
- Removes Laravel v6 & v5.8 support.
- Implements spatie/laravel-package-tools.
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._