### PR TITLE
WIP add ability to throttle failure notifications

### DIFF
--- a/config/failed-job-monitor.php
+++ b/config/failed-job-monitor.php
@@ -15,6 +15,16 @@ return [
     'notifiable' => \Spatie\FailedJobMonitor\Notifiable::class,
 
     /*
+     * Number of seconds to wait before sending another notification
+     */
+    'throtteling' => false,
+
+    /*
+     * Number of seconds to wait before sending another notification
+     */
+    'throtteling_cache_store' => 'file',
+
+    /*
      * By default notifications are sent for all failures. You can pass a callable to filter
      * out certain notifications. The given callable will receive the notification. If the callable
      * return false, the notification will not be sent.


### PR DESCRIPTION
This code is entirely untested, but I wanted to open the PR to see if there is interest in adding this functionality. It can also be implemented via a notificationFilter but I thought maybe this should be provided out of the box.

Backstory:
Yesterday I deployed broken code and ended up sending out 400 emails to our internal engineering mailing list :)