### PR TITLE
Allow multiple email addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ return [
     'channels' => ['mail', 'slack'],
 
     'mail' => [
-        'to' => 'email@example.com',
+        'to' => ['email@example.com'],
     ],
 
     'slack' => [

--- a/config/failed-job-monitor.php
+++ b/config/failed-job-monitor.php
@@ -27,7 +27,7 @@ return [
     'channels' => ['mail', 'slack'],
 
     'mail' => [
-        'to' => 'email@example.com',
+        'to' => ['email@example.com'],
     ],
 
     'slack' => [

--- a/src/Notifiable.php
+++ b/src/Notifiable.php
@@ -8,9 +8,15 @@ class Notifiable
 {
     use NotifiableTrait;
 
-    public function routeNotificationForMail(): string
+    public function routeNotificationForMail(): array
     {
-        return config('failed-job-monitor.mail.to');
+        $recipients = config('failed-job-monitor.mail.to');
+
+        if (is_string($recipients)) {
+            return [$recipients];
+        }
+
+        return $recipients;
     }
 
     public function routeNotificationForSlack(): string

--- a/tests/NotifiableTest.php
+++ b/tests/NotifiableTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\FailedJobMonitor\Test;
+
+use Spatie\FailedJobMonitor\Notifiable;
+
+class NotifiableTest extends TestCase
+{
+    /** @test */
+    public function it_returns_always_list_of_emails()
+    {
+        $notifiable = new Notifiable();
+
+        $this->app['config']->set('failed-job-monitor.mail.to', 'example@gmail.com');
+        $this->assertEquals(['example@gmail.com'], $notifiable->routeNotificationForMail());
+
+        $recipients = ['example@gmail.com', 'example2@gmail.com'];
+        $this->app['config']->set('failed-job-monitor.mail.to', $recipients);
+        $this->assertEquals($recipients, $notifiable->routeNotificationForMail());
+    }
+}


### PR DESCRIPTION
Thank you for this great package. It has really nice features that are very useful for developers. I was just wondering if would it be nice to have the possibility to define more than one email address.

This may break backward compatibility because the returning type of routeNotificationForMail method has been changed. It would be nice if this feature can be part of the next major release if it's possible.

Let me know if you have any questions.

Thanks!