### PR TITLE
Hide link in mail when not using Horizon

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -38,7 +38,7 @@ class Notification extends IlluminateNotification
             ->line("Job class: {$this->event->job->resolveName()}")
             ->line("Job body: {$this->event->job->getRawBody()}")
             ->line("Exception: {$this->event->exception->getTraceAsString()}")
-            ->action('View Error', url(config('horizon.path').'/failed/'.$this->event->job->getJobId()));
+            ->when(config('horizon') !== null, fn (MailMessage $mailMessage) => $mailMessage->action('View Error', url(config('horizon.path').'/failed/'.$this->event->job->getJobId())));
     }
 
     public function toSlack(): SlackMessage


### PR DESCRIPTION
In https://github.com/spatie/laravel-failed-job-monitor/pull/84 the button to view the failed job in Horizon was added, but not everybody might be using Horizon. This Pull Request hides the button when the Horizon config is empty (so not using Horizon).