### PR TITLE
more sensible defaults

### DIFF
--- a/config/failed-job-monitor.php
+++ b/config/failed-job-monitor.php
@@ -27,7 +27,7 @@ return [
     'channels' => ['mail', 'slack'],
 
     'mail' => [
-        'to' => ['email@example.com'],
+        'to' => ['spatie-failed-job@example.com'],
     ],
 
     'slack' => [


### PR DESCRIPTION
1. Make it easier to trace bounced/failed emails back to this package using `spatie-failed-job@example.com`
2. In fact, I would even disable slack by default, because 
    - the error `Driver [slack] not supported.` is very vague when `FAILED_JOB_SLACK_WEBHOOK_URL` is not provided, no indication it is caused by this package
    - I suspect among those who install this, lesser of them have a slack webhook URL